### PR TITLE
ubuntugis is missing for 20.04 ubuntu, switch to 18.04 tmp

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -27,16 +27,16 @@ jobs:
           - {os: macOS-latest,   r: 'oldrel',  java: 8}
           - {os: windows-latest, r: 'release', java: 8}
           - {os: windows-latest, r: 'oldrel',  java: 8}
-          - {os: ubuntu-latest,  r: 'devel',   java: 8}
-          - {os: ubuntu-latest,  r: 'release', java: 8}
-          - {os: ubuntu-latest,  r: 'oldrel',  java: 8}
+          - {os: ubuntu-18.04,  r: 'devel',   java: 8}
+          - {os: ubuntu-18.04,  r: 'release', java: 8}
+          - {os: ubuntu-18.04,  r: 'oldrel',  java: 8}
           - {os: macOS-latest,   r: 'release', java: 11}
           - {os: macOS-latest,   r: 'oldrel',  java: 11}
           - {os: windows-latest, r: 'release', java: 11}
           - {os: windows-latest, r: 'oldrel',  java: 11}
-          - {os: ubuntu-latest,  r: 'devel',   java: 11}
-          - {os: ubuntu-latest,  r: 'release', java: 11}
-          - {os: ubuntu-latest,  r: 'oldrel',  java: 11}
+          - {os: ubuntu-18.04,  r: 'devel',   java: 11}
+          - {os: ubuntu-18.04,  r: 'release', java: 11}
+          - {os: ubuntu-18.04,  r: 'oldrel',  java: 11}
 
 
     env:


### PR DESCRIPTION
This fixes should fix Ubuntu builds, falling back on 18.04 as ubuntugis is not available for focal.